### PR TITLE
Update mission.sqf

### DIFF
--- a/core/def/mission.sqf
+++ b/core/def/mission.sqf
@@ -315,7 +315,8 @@ if (isServer) then {
 				"ACE_medicalSupplyCrate",
 				"B_supplyCrate_F",
 				"B_CargoNet_01_ammo_F",
-				"Box_NATO_AmmoVeh_F"
+				"Box_NATO_AmmoVeh_F",
+				"Land_WoodenBox_F"
 			],
 			[
 				//"Containers"


### PR DESCRIPTION
Add woodenbox object in 'require object' area so players can have an 'empty ammo box' to put stuff in and take